### PR TITLE
Switch MelConnection to asyncio streams

### DIFF
--- a/custom_components/mitsubishi_local/connection.py
+++ b/custom_components/mitsubishi_local/connection.py
@@ -1,7 +1,6 @@
 """Connection handler for Mitsubishi AC units."""
 import asyncio
 import logging
-import socket
 from typing import Optional
 
 _LOGGER = logging.getLogger(__name__)
@@ -14,47 +13,55 @@ class MelConnection:
         self._host = host
         self._port = port
         self._timeout = timeout
-        self._socket: Optional[socket.socket] = None
+        self._reader: Optional[asyncio.StreamReader] = None
+        self._writer: Optional[asyncio.StreamWriter] = None
         self._lock = asyncio.Lock()
     
     async def connect(self) -> None:
         """Establish connection with the AC unit."""
-        if self._socket is not None:
+        if self._writer is not None:
             return
-            
+
         try:
-            self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self._socket.settimeout(self._timeout)
-            self._socket.connect((self._host, self._port))
+            self._reader, self._writer = await asyncio.wait_for(
+                asyncio.open_connection(self._host, self._port),
+                timeout=self._timeout,
+            )
         except Exception as e:
-            self._socket = None
+            self._reader = None
+            self._writer = None
             _LOGGER.error("Failed to connect to %s:%d: %s", self._host, self._port, e)
             raise
     
     async def disconnect(self) -> None:
         """Close the connection."""
-        if self._socket is not None:
+        if self._writer is not None:
             try:
-                self._socket.close()
+                self._writer.close()
+                await self._writer.wait_closed()
             except Exception as e:
                 _LOGGER.error("Error closing connection: %s", e)
             finally:
-                self._socket = None
+                self._reader = None
+                self._writer = None
     
     async def send_command(self, command: bytes) -> bytes:
         """Send a command and receive the response."""
         async with self._lock:
             await self.connect()
-            
+
             try:
-                self._socket.send(command)
-                response = self._socket.recv(1024)
-                
+                assert self._writer is not None and self._reader is not None
+                self._writer.write(command)
+                await self._writer.drain()
+                response = await asyncio.wait_for(self._reader.read(1024), self._timeout)
+
                 if not response:
                     raise ConnectionError("No response received")
-                    
+
                 return response
             except Exception as e:
                 _LOGGER.error("Error sending command: %s", e)
                 await self.disconnect()
                 raise
+


### PR DESCRIPTION
## Summary
- use `asyncio.open_connection` in `MelConnection`
- send/receive using async streams

## Testing
- `python -m py_compile custom_components/mitsubishi_local/connection.py`
- `python -m py_compile custom_components/mitsubishi_local/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68406077242083258729c9bed9aae511